### PR TITLE
also bootstraping tests because tests are good and we should test more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ npm-debug.log
 /test
 /coverage
 /.nyc_output
+test-report.xml
 
 # dist
 /dist
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ $ npm install
 $ npm run start
 ```
 
+
+## Tests with code coverage
+
+```
+$ npm run test
+```
+
 ## People
 
 - Author - [Kamil Myśliwiec](https://kamilmysliwiec.com)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node index.js",
     "start:watch": "nodemon",
     "prestart:prod": "tsc",
-    "start:prod": "node dist/main.js"
+    "start:prod": "node dist/main.js",
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@nestjs/common": "^4.5.9",
@@ -21,8 +22,27 @@
     "typescript": "^2.6.2"
   },
   "devDependencies": {
+    "@types/jest": "^22.1.3",
     "@types/node": "^9.3.0",
+    "jest": "^22.4.2",
+    "jest-sonar-reporter": "^1.3.0",
     "nodemon": "^1.14.1",
+    "ts-jest": "^22.0.4",
     "ts-node": "^4.1.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testResultsProcessor": "jest-sonar-reporter",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/src/app.spec.ts
+++ b/src/app.spec.ts
@@ -1,0 +1,18 @@
+import 'jest';
+import { Test } from '@nestjs/testing';
+import { AppController } from './app.controller';
+
+describe('App tests', () => {
+  let controller: AppController;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [ AppController ]
+    }).compile();
+    controller = module.get<AppController>(AppController);
+  });
+
+  it('should say hello world', async () => {
+    expect(controller.root()).toBe('Hello World!');
+  });
+});


### PR DESCRIPTION
A review of the changes :

- gitignore : test-report generated by jest, is now ignored
- package.json : adding jest dependencies, configuration, and start command (`npm run test`)
- app.spec.ts : a test file that will be used as sample by the bootstraps users I guess.

Testing was not really hard to set up, but I think a bootstrap should have it. Anyway, this is open source right ? I'm contribooting 🥇 

Cheers 🥂 
