### PR TITLE
refactor: Uses process.env.PORT to start app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,6 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(3000);
+  await app.listen(process.env.PORT || 3000);
 }
 bootstrap();


### PR DESCRIPTION
This will fix a bug in the heroku deploy (and other containers deployments)

Fix a bug "Error R10 (Boot timeout) -> Web process failed to bind to $PORT within 60 seconds of launch" in heroku

The 3000 port will be used if process.env.PORT are not set