### PR TITLE
Fix using HttpService in e2e tests

### DIFF
--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,6 +1,7 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
+  "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"


### PR DESCRIPTION
HttpService did not work in e2e tests because Jest testEnvironment was
jsdom by default. HttpService threw NetworkError on each request because
axios uses XHR adapter instead of HTTP adapter in this environment.

Now, Jest testEnvironment is node.