### PR TITLE
move typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "@nestjs/websockets": "^5.1.0",
     "@types/node": "^10.7.1",
     "reflect-metadata": "^0.1.12",
-    "rxjs": "^6.2.2",
-    "typescript": "^3.0.1"
+    "rxjs": "^6.2.2"
   },
   "devDependencies": {
     "@types/express": "^4.16.0",
@@ -43,6 +42,7 @@
     "ts-node": "^7.0.1",
     "tsconfig-paths": "^3.5.0",
     "tslint": "5.11.0",
+    "typescript": "^3.0.1",
     "webpack": "^4.16.5",
     "webpack-cli": "^3.1.0",
     "webpack-node-externals": "^1.7.2"


### PR DESCRIPTION
`typescript` is not needed to run production application, only to build the code

fixes #47 