### PR TITLE
make it easier to try the starter

### DIFF
--- a/.gitpod
+++ b/.gitpod
@@ -1,0 +1,6 @@
+
+ports:
+  - port: 3000
+    protocol: "http"
+tasks:
+  - command: "npm install && npm run start:dev"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [travis-url]: https://travis-ci.org/nestjs/nest
 [linux-image]: https://img.shields.io/travis/nestjs/nest/master.svg?label=linux
 [linux-url]: https://travis-ci.org/nestjs/nest
-  
+
   <p align="center">A progressive <a href="http://nodejs.org" target="blank">Node.js</a> framework for building efficient and scalable server-side applications, heavily inspired by <a href="https://angular.io" target="blank">Angular</a>.</p>
     <p align="center">
 <a href="https://www.npmjs.com/~nestjscore"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
@@ -31,8 +31,14 @@
 ## Installation
 
 ```bash
+$ git clone https://github.com/nestjs/typescript-starter.git project
+$ cd project
 $ npm install
 ```
+
+### From your browser
+
+[Open in Gitpod](https://gitpod.io#https://github.com/nestjs/typescript-starter) - launches a cloud container, installs dependencies, starts a dev server and opens it in a VS-code like browser IDE.
 
 ## Running the app
 


### PR DESCRIPTION
Hi 👋 We've launched a public beta of [Gitpod](https://medium.com/gitpod/gitpod-gitpod-online-ide-for-github-6296b907a886). It's a VS Code-powered IDE and a cloud-based Linux container configured specifically for the project at hand, for example one can configure which tooling should be installed via Docker images and startup commands to run to improve onboarding experince.

How it works for the starter repo:
![nestjs](https://user-images.githubusercontent.com/3082655/45600062-dfa49a00-b9f6-11e8-91ea-0bd9f3d4eacb.gif)

In order to try it yourself: https://gitpod.io#https://github.com/nestjs/typescript-starter.

We will be glad to hear what is missing to make it work for this case, plese file issues [here](https://github.com/gitpod-io/gitpod).
