### PR TITLE
tsconfig-paths/register to debug task so base url references work

### DIFF
--- a/nodemon-debug.json
+++ b/nodemon-debug.json
@@ -2,5 +2,5 @@
   "watch": ["src"],
   "ext": "ts",
   "ignore": ["src/**/*.spec.ts"],
-  "exec": "node --inspect-brk -r ts-node/register src/main.ts"
+  "exec": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register src/main.ts"
 }


### PR DESCRIPTION
Using the baseUrl in the tsconfig file, TS will do auto imports using the base url (`app/mycode` instead of `./app/mycode`). In order for this to work, the tsconfig-paths must be loaded so TS knows where to find the appropriate files. This was being done for the normal start task, but not the debug one.