### PR TITLE
Include default VSCode workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "debug.node.autoAttach": "on"
+}


### PR DESCRIPTION
Enable AutoAttach for debugging.
Related: #37