### PR TITLE
bugfix: set rootDir for jest in package.json to '.' instead of 'src'

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"


### PR DESCRIPTION
Tests cannot be found if they are in the test directory