### PR TITLE
include untested files in coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
   }


### PR DESCRIPTION
jest coverage report ignores untested files by default, which results in incorrect coverage summary when some files lack tests. see also: https://jestjs.io/docs/en/configuration#collectcoveragefrom-array https://github.com/facebook/jest/issues/1211