### PR TITLE
Fix start:prod and start:dev commands.

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["dist"],
   "ext": "js",
-  "exec": "node dist/main"
+  "exec": "node -r ts-node/register/transpile-only -r tsconfig-paths/register dist/main"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start:dev": "concurrently --handle-input \"wait-on dist/main.js && nodemon\" \"tsc -w -p tsconfig.build.json\" ",
     "start:debug": "nodemon --config nodemon-debug.json",
     "prestart:prod": "rimraf dist && npm run build",
-    "start:prod": "node dist/main.js",
+    "start:prod": "node -r ts-node/register/transpile-only -r tsconfig-paths/register dist/main.js",
     "lint": "tslint -p tsconfig.json -c tslint.json",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
Fix commands for custom typescript path aliases.
Example: 
`tsconfig.json`
```json

  "paths": {
      "@/*": [
        "./src/*"
      ]
    }
```
`src/app.module.ts`
```typescript
import { AppController } from '@/app.controller';
import { AppService } from '@/app.service';

```
