### PR TITLE
Change tsc target to esnext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es6",
+    "target": "esnext",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
If tsc target is `es6`, then the code doesn't use native async/await syntax. Target `esnext` fixes this problem.

es6 target:
<img width="763" alt="Screen Shot 2019-05-23 at 12 51 26" src="https://user-images.githubusercontent.com/347044/58243694-d1fb9d00-7d59-11e9-86b1-fa6c916b929d.png">

esnext target:
<img width="759" alt="Screen Shot 2019-05-23 at 12 52 10" src="https://user-images.githubusercontent.com/347044/58243726-dfb12280-7d59-11e9-9128-f0a075d8aecc.png">
