### PR TITLE
fix(): jest modulePath to resolve modules using absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
       "ts"
     ],
     "rootDir": "src",
+    "modulePaths": [
+      "<rootDir>/../"
+    ],
     "testRegex": ".spec.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"


### PR DESCRIPTION
Currently jest configuration cannot resolve modules that are imported using absolute paths like `src/<filename>` and throws error.

**Steps to reproduce:**

1. In `src/app.controller.ts`
    ```
    // Change
    
    import { AppService } from './app.service';
    
    // to
    
    import { AppService } from 'src/app.service';
    
    ```
1. Run `npm start`, it works perfectly.
1. Run `npm test`
    ```
    > jest
    
     FAIL  src/app.controller.spec.ts
      ● Test suite failed to run
    
        Cannot find module 'src/app.service' from 'app.controller.ts'
    
        Require stack:
          app.controller.ts
          app.controller.spec.ts
    
          1 | import { Controller, Get } from '@nestjs/common';
        > 2 | import { AppService } from 'src/app.service';
            | ^
          3 | 
          4 | @Controller()
          5 | export class AppController {
    
          at Resolver.resolveModule (../node_modules/jest-resolve/build/index.js:299:11)
          at Object.<anonymous> (app.controller.ts:2:1)
    
    Test Suites: 1 failed, 1 total
    Tests:       0 total
    Snapshots:   0 total
    Time:        0.934s, estimated 2s
    Ran all test suites.
    ```

**Solution**
Add `modulePaths` attribute as seen in the pull request. 