### PR TITLE
Remove incremental:true because it is already the default value

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
-    "incremental": true
+    "baseUrl": "./"
   }
 }


### PR DESCRIPTION
The "incremental" option defaults to true, so it is not necessary to specify:
https://www.typescriptlang.org/v2/en/tsconfig#incremental