### PR TITLE
Fixed prettier - Added 'plugin:prettier/recommended' to eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   extends: [
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
+    'plugin:prettier/recommended',
     'prettier/@typescript-eslint',
   ],
   root: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4833,6 +4833,15 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz",
+      "integrity": "sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -5286,6 +5295,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -10220,6 +10235,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
       "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "25.5.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.0.1",
     "prettier": "^2.0.5",
     "supertest": "^4.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
With the current configuration the prettier doesn't work . It just ignores the prettier part.
I've used the same configuration files (`prettierrc`, `tsconfig.json`, `eslintrc.js`) from this repo.

I've made intentionally some code style mistakes in `src/main.ts` file.
![image](https://user-images.githubusercontent.com/6481499/89915123-a551d080-dbfe-11ea-8939-18d59faaae62.png)

Running `eslint src/main.ts` with this repo configuration, didn't throw any errors.
![image](https://user-images.githubusercontent.com/6481499/89916093-d8e12a80-dbff-11ea-8556-b42bf1ba1020.png)

By adding the line `'plugin:prettier/recommended'` to the `extends` section of `eslintrc.js`, the prettier started to work correctly.
![image](https://user-images.githubusercontent.com/6481499/89916155-f7dfbc80-dbff-11ea-873a-abf49905dd67.png)

Useful article: https://www.robertcooper.me/using-eslint-and-prettier-in-a-typescript-project

EDIT: 
Also, found out a bit later that without having `"esModuleInterop": true` set on `true` in `tsconfig.js`, causes different weird errors, like this:
![image](https://user-images.githubusercontent.com/6481499/90082998-f7d3df80-dd19-11ea-80e8-f8d82eae6e93.png)


