### PR TITLE
fix: stricten unit test file pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },


### PR DESCRIPTION
The unit test file pattern strictly follows the .spec.ts file suffix. This rules out .e2e-spec.ts files from unit tests.

Relates to nestjs/nest#5293