### PR TITLE
fix(): add .vscode ide files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,6 +330,13 @@ paket-files/
 .idea/
 *.sln.iml
 
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json`;
+
 # CodeRush
 .cr/
 

--- a/.gitignore
+++ b/.gitignore
@@ -335,7 +335,7 @@ paket-files/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
-!.vscode/extensions.json`;
+!.vscode/extensions.json
 
 # CodeRush
 .cr/


### PR DESCRIPTION
.vscode is added to gitignore

This is nest-cli default vscode options!