### PR TITLE
feat(): enable strict mode for typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "strictPropertyInitialization": false,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Note: this is an identical PR to https://github.com/nestjs/schematics/pull/587,
just against the standalone template repository.

Strict mode is a good default for new projects, because it prevents
accidental omission of type safety information. It's much easier to
maintain strict mode compatibility from the start than it is to
retrofit a mature project to support strict mode.

That said, it's useful to default strictPropertyInitialization to
false for Nest projects, since the class-validator DTO pattern
described in the documentation is not compatible with strict property
initialization.