### PR TITLE
chore(eslintrc): add endOfLine to the rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      },
+    ],
   },
 };


### PR DESCRIPTION
When end of line is set to `CRLF`  vscode shows error. (when creating file the default is `CRLF`. I had to add that to the file. I think maybe it's a good idea to have it in the starter repo.