### PR TITLE
set strict compiler option to true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "incremental": true
+    "incremental": true,
+    "strict": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
-    "strict": true
+    "strict": true,
+    "strictPropertyInitialization": false
   }
 }


### PR DESCRIPTION
Hey guys, I propose this change because I encountered a problem in one project generated with this template and I am pretty sure others might as well.

Here is the type with `"strict": true` 

![image](https://user-images.githubusercontent.com/31855017/111890489-1db41780-89c0-11eb-9e84-fe191b66c3ce.png)

This is the expected type of the `find` method

here is the type without it.

![image](https://user-images.githubusercontent.com/31855017/111890515-64a20d00-89c0-11eb-932d-8e1baf4e8518.png)

The return type does not represent the one expected from the returned balue of the `Array.find` method.

For more info on strict compiler option : https://www.typescriptlang.org/tsconfig#strict

Edit: Since typeorm entities do not require property initialization, I added the `"strictPropertyInitialization": false` option to the tsconfig