### PR TITLE
Log server url on application start

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,5 +4,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(3000);
+  console.log(`Application is running on: ${await app.getUrl()}`);
 }
 bootstrap();


### PR DESCRIPTION
It is helpful to see the server url (inluding the port) in the logs after the application started.

In the samples of the nestjs the server url will be already logged.
https://github.com/nestjs/nest/tree/master/sample