### PR TITLE
add `$schema` entry to nest-cli.json file

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/nest-cli",
   "collection": "@nestjs/schematics",
   "sourceRoot": "src"
 }


### PR DESCRIPTION
The schema URL was taken from here: https://www.schemastore.org/json and was reviewed here: https://github.com/SchemaStore/schemastore/pull/1947

This is just to help devs on building the `nest-cli.json` file in their IDE/code editor. We'll get no errors if some field is not allowed but we'll get autocompletion for the ones that are allowed

![image](https://user-images.githubusercontent.com/13461315/160671891-69401520-4622-4387-8dad-3aad08b7ae8b.png)

Should we add this on `@nestjs/schematics` as well? :thinking: 
