### PR TITLE
chore: changes in tsconfig and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,5 @@ Temporary Items
 # Local
 .env
 dist
+.webpack
+.serverless/**/*.zip

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2017",
+    "target": "ES2019",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
According to:

https://github.com/nestjs/nest/blob/master/package.json#L175-L177

The minimum NodeJS version for NestJS apps is 12.x, and using [Node Target Mapping](https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-12), we can increase the version target to es2019.

Also, I added the `include` option to include only the `src` and `test` folders, without this option, if we add any folder with a .ts file in the root, when we build the application, the result will be something like:

- src
- new folder

With this option, we avoid this behavior. Another solution is to mark `new-folder` as excluded from `tsconfig.build.json` but I haven't thought of anywhere to put this information and it's easier to say exactly what we consider to be part of the build.

To finalize, I added `.webpack` and `.serverless` folder to .gitignore, we can produce this folders when we integrate with serverless.

---

I can also generate another `package-lock.json` using the new npm version, which changes `lockfileVersion` to 2.
And the `rimraf` package shouldn't be listed in the production dependencies, it should be in the development dependencies. Should I create another PR or can I send two more commits for these modifications?