### PR TITLE
chore: remove unnecessary type

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -14,7 +14,7 @@ describe('AppController', () => {
 
   describe('getHello', () => {
     it('should return "Hello World!"', () => {
-      const appController = app.get<AppController>(AppController);
+      const appController = app.get(AppController);
       expect(appController.getHello()).toBe('Hello World!');
     });
   });


### PR DESCRIPTION
TypeScript already knows it will be an `AppController` in this context.