### PR TITLE
esModuleInterop instead of syntheticDefaultImports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
`esModuleInterop` Option automatically enables the `allowSyntheticDefaultImports` option that enables this import to working fine when compiling using tsc:

```ts
import path from "node:path"
```