### PR TITLE
feat: add minimal repl setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "repl": "nest start --entryFile repl --watch",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,0 +1,8 @@
+import { repl } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  await repl(AppModule);
+}
+
+bootstrap();


### PR DESCRIPTION
to encourage the usage of [Nestjs REPL](https://docs.nestjs.com/recipes/repl), we could have a basic setup which includes:

- a new slim `src/repl.ts` file
- a new npm-script called `repl` that starts the REPL with watch mode