### PR TITLE
close app handle in base e2e test

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -15,6 +15,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterAll(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')


### PR DESCRIPTION
small patch so that jest doesn't hang on the open connection of the app instance during e2e testing