### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
-        "@nestjs/cli": "^10.0.1",
-        "@nestjs/schematics": "^10.0.1",
         "@nestjs/testing": "^10.0.0",
         "@swc/cli": "^0.1.62",
         "@swc/core": "^1.3.64",
@@ -1357,54 +1355,6 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
-    "node_modules/@nestjs/cli": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-10.1.0.tgz",
-      "integrity": "sha512-R/n+cFIvK3YbFSU9t7NFyBgXJRDK1biCZgz1VqYdpZj4JmIj8RmllA9Fp3YZUg98D8K7T4HoIuVFUAkEFSSLTg==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/core": "16.1.3",
-        "@angular-devkit/schematics": "16.1.3",
-        "@angular-devkit/schematics-cli": "16.1.3",
-        "@nestjs/schematics": "^10.0.1",
-        "chalk": "4.1.2",
-        "chokidar": "3.5.3",
-        "cli-table3": "0.6.3",
-        "commander": "4.1.1",
-        "fork-ts-checker-webpack-plugin": "8.0.0",
-        "inquirer": "8.2.5",
-        "node-emoji": "1.11.0",
-        "ora": "5.4.1",
-        "os-name": "4.0.1",
-        "rimraf": "4.4.1",
-        "shelljs": "0.8.5",
-        "source-map-support": "0.5.21",
-        "tree-kill": "1.2.2",
-        "tsconfig-paths": "4.2.0",
-        "tsconfig-paths-webpack-plugin": "4.0.1",
-        "typescript": "5.1.6",
-        "webpack": "5.88.1",
-        "webpack-node-externals": "3.0.0"
-      },
-      "bin": {
-        "nest": "bin/nest.js"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "peerDependencies": {
-        "@swc/cli": "^0.1.62",
-        "@swc/core": "^1.3.62"
-      },
-      "peerDependenciesMeta": {
-        "@swc/cli": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nestjs/common": {
       "version": "10.0.4",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.0.4.tgz",
@@ -1488,22 +1438,6 @@
       "peerDependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0"
-      }
-    },
-    "node_modules/@nestjs/schematics": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-10.0.1.tgz",
-      "integrity": "sha512-buxpYtSwOmWyf0nUJWJCkCkYITwbOfIEKHTnGS7sDbcfaajrOFXb5pPAGD2E1CUb3C1+NkQIURPKzs0IouZTQg==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/core": "16.1.0",
-        "@angular-devkit/schematics": "16.1.0",
-        "comment-json": "4.2.3",
-        "jsonc-parser": "3.2.0",
-        "pluralize": "8.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.2"
       }
     },
     "node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@nestjs/cli": "^10.0.1",
-    "@nestjs/schematics": "^10.0.1",
     "@nestjs/testing": "^10.0.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.64",


### PR DESCRIPTION
I only removed the dependencies @nestjs/cli & @nestjs/schematic because they have already been installed globally. If you still want to use them, please make sure to monitor and update their dependencies, as every time I use the nest new my-app command, it always installs those packages, which are not actually needed to start a project.