### PR TITLE
chore: specify node engine version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
fixed: [#12417](https://github.com/nestjs/nest/issues/12417)