### PR TITLE
chore: remove redundant dependency on `@nestjs/schematics`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.1",
-        "@nestjs/schematics": "^10.0.1",
         "@nestjs/testing": "^10.0.0",
         "@swc/cli": "^0.1.62",
         "@swc/core": "^1.3.64",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.1",
-    "@nestjs/schematics": "^10.0.1",
     "@nestjs/testing": "^10.0.0",
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.64",


### PR DESCRIPTION
as per PR https://github.com/nestjs/schematics/pull/1542

after this, the dep graph looks like this:

```
$  npm ls @nestjs/schematics
nest-typescript-starter@1.0.0 /tmp/typescript-starter
└─┬ @nestjs/cli@10.1.18
  └── @nestjs/schematics@10.0.2
```