### PR TITLE
tsconfig: add lib field explicitly to exclude dom related apis

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "lib": ["ES2023"],
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
fix https://github.com/nestjs/typescript-starter/issues/288

Set [lib](https://www.typescriptlang.org/tsconfig#lib) field to `ES2023`.

Ref: [node-lts.json](https://github.com/tsconfig/bases/blob/main/bases/node-lts.json), [node18.json](https://github.com/tsconfig/bases/blob/main/bases/node18.json), [node19.json](https://github.com/tsconfig/bases/blob/main/bases/node19.json), [node20.json](https://github.com/tsconfig/bases/blob/main/bases/node20.json) of https://github.com/tsconfig/bases repo.