### PR TITLE
Fix a regular expression incorrectly in testRegex in jest-e2e.json

### DIFF
--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -2,7 +2,7 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testRegex": "\\.e2e-spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }


### PR DESCRIPTION
The following files were also matched by regular expression.

* appe2e-spec.ts
* appe2e-specxts

Fixed by escaping `.`.