### PR TITLE
enable `forceConsistentCasingInFileNames` for tsc compiler options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true
   }
 }


### PR DESCRIPTION
that flag will help on preventing 'dependency not found errors' that windows users might face due to misspelled file names

Full code: https://github.com/micalevisk/testes-gh

For example, assuming that we didn't supply `forceConsistentCasingInFileNames`:

![image](https://github.com/user-attachments/assets/81f8a2da-5e54-4332-ab15-cc2ecee31cdf)

that code will compile on Windows, I tested the `npm run build` command on GitHub Action's Windows:

![image](https://github.com/user-attachments/assets/0b918c85-62c5-4502-83b7-1f2758efba8c)

but it won't work at runtime:

![image](https://github.com/user-attachments/assets/f3414124-b41e-4aa7-80c3-e73233e70562)

---

After adding `forceConsistentCasingInFileNames: true`, it will start breaking on compilation time just like we have on Linux:

![image](https://github.com/user-attachments/assets/cfce55e0-455a-4e12-bfec-72f93f4b3090)


I'm not sure if this is something that Nest could circumvent, this is why I'd rather suggest enabling that flag