### PR TITLE
Configure onlyBuiltDependencies for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,11 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@swc/core"
+    ]
   }
 }


### PR DESCRIPTION
`pnpm` triggers a warning when you're installing the dependencies, which can be avoided by configuring `pnpm.onlyBuiltDependencies` via `package.json`.

```
╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: @nestjs/core, @swc/core.                                          │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```