### PR TITLE
feat(tsconfig): Enable ESM-interoperability.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "resolvePackageJsonExports": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
These are the changes I made in my own project to enable ESM interoperability, based on the following advice: https://github.com/octokit/octokit.js/issues/2865#issuecomment-3013614492

I've been using it for several weeks now and it's been working well without any issues. The only problem I've had is that `jest` didn't play nicely with ESM. I had to add `"isolatedModules": true` to suppress a warning and so far the best solution I've found for testing ESM with `jest` is to simply mock the ESM imports and test with mocks instead. This is fine for me, since the ESM dependency I have is `Octokit` and I don't want to be making http requests to GitHub during testing anyway.

Regardless, it seems better to have ESM interoperability, than not having it, even though it's a bit lacking in the `jest` environment.