### PR TITLE
fix: configure prettier endOfLine to 'auto' for cross-platform compatibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,7 +28,8 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      "prettier/prettier": ["error", { endOfLine: "auto" }],
     },
   },
 );


### PR DESCRIPTION
Windows developers encounter ESLint/Prettier errors due to CRLF line endings, while the repo expects LF. Setting endOfLine: 'auto' allows Prettier to normalize based on detected format.