### PR TITLE
chore: Add void to mark bootstrap Promise as intentionally not awaited

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,4 +5,4 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(3000);
 }
-bootstrap();
+void bootstrap();


### PR DESCRIPTION
- The `npm run lint` returns a warning about the `bootstrap` function inside `main.ts`.
- Since this function is being used at the top level of a CommonJS module, we cannot use `await` here.
- We should fix it by adding the keyword `void` to mark the Promise `bootstrap` function as intentionally not awaited.
- References: https://typescript-eslint.io/rules/no-floating-promises/#ignorevoid